### PR TITLE
avoid nested omp for single-gpu env and enable omp threshold for thru…

### DIFF
--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -418,10 +418,10 @@ public:
   void StoreOffsets(const std::vector<uint_t>& ptr);
 
   template <typename Function>
-  int Execute(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid,uint_t localMask);
+  int Execute(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid,uint_t localMask, bool omp_parallel);
 
   template <typename Function>
-  double ExecuteSum(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid,uint_t localMask);
+  double ExecuteSum(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid, uint_t localMask, bool omp_parallel);
 
   void SetParams(struct GateParams<data_t>& params);
 
@@ -688,7 +688,7 @@ void QubitVectorChunkContainer<data_t>::StoreOffsets(const std::vector<uint_t>& 
 
 template <typename data_t>
 template <typename Function>
-int QubitVectorChunkContainer<data_t>::Execute(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid,uint_t localMask)
+int QubitVectorChunkContainer<data_t>::Execute(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid,uint_t localMask, bool omp_parallel)
 {
   struct GateParams<data_t> params;
 
@@ -718,7 +718,11 @@ int QubitVectorChunkContainer<data_t>::Execute(std::vector<uint_t>& offsets,Func
     thrust::for_each_n(thrust::device, chunkIter, size, func);
   }
   else{
-    thrust::for_each_n(thrust::omp::par, chunkIter, size, func);
+    if (omp_parallel) {
+      thrust::for_each_n(thrust::omp::par, chunkIter, size, func);
+    } else {
+      thrust::for_each_n(thrust::seq, chunkIter, size, func);
+    }
   }
 
   return 0;
@@ -726,7 +730,7 @@ int QubitVectorChunkContainer<data_t>::Execute(std::vector<uint_t>& offsets,Func
 
 template <typename data_t>
 template <typename Function>
-double QubitVectorChunkContainer<data_t>::ExecuteSum(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid,uint_t localMask)
+double QubitVectorChunkContainer<data_t>::ExecuteSum(std::vector<uint_t>& offsets,Function func,uint_t size,uint_t gid,uint_t localMask, bool omp_parallel)
 {
   struct GateParams<data_t> params;
   double ret;
@@ -757,7 +761,11 @@ double QubitVectorChunkContainer<data_t>::ExecuteSum(std::vector<uint_t>& offset
     ret = thrust::transform_reduce(thrust::device, chunkIter, chunkIter + size, func,0.0,thrust::plus<double>());
   }
   else{
-    ret = thrust::transform_reduce(thrust::omp::par, chunkIter, chunkIter + size, func,0.0,thrust::plus<double>());
+    if (omp_parallel) {
+      ret = thrust::transform_reduce(thrust::omp::par, chunkIter, chunkIter + size, func,0.0,thrust::plus<double>());
+    } else {
+      ret = thrust::transform_reduce(thrust::seq, chunkIter, chunkIter + size, func,0.0,thrust::plus<double>());
+    }
   }
   return ret;
 }
@@ -2134,7 +2142,7 @@ double QubitVectorThrust<data_t>::apply_function(Function func,const reg_t &qubi
   }
 
   if(noDataExchange){
-#pragma omp parallel private(size,iChunk,i,ib) num_threads(m_nPlaces)
+#pragma omp parallel if (num_qubits_ > omp_threshold_ && m_nPlaces > 1) private(size,iChunk,i,ib) num_threads(m_nPlaces)
     {
       int iPlace = omp_get_thread_num();
       uint_t localMask = 0xffffffff;
@@ -2146,9 +2154,9 @@ double QubitVectorThrust<data_t>::apply_function(Function func,const reg_t &qubi
 
       //execute kernel
       if(func.Reduction())
-        ret += m_Chunks[iPlace].ExecuteSum(offsetBase,func,size,m_Chunks[iPlace].ChunkID(0,0),localMask);
+        ret += m_Chunks[iPlace].ExecuteSum(offsetBase,func,size,m_Chunks[iPlace].ChunkID(0,0),localMask, omp_threshold_ < num_qubits_);
       else
-        m_Chunks[iPlace].Execute(offsetBase,func,size,m_Chunks[iPlace].ChunkID(0,0),localMask);
+        m_Chunks[iPlace].Execute(offsetBase,func,size,m_Chunks[iPlace].ChunkID(0,0),localMask, omp_threshold_ < num_qubits_);
     }
   }
   else{
@@ -2162,7 +2170,7 @@ double QubitVectorThrust<data_t>::apply_function(Function func,const reg_t &qubi
       controlFlag = controlMask;
     }
 
-#pragma omp parallel private(iChunk,i,ib) num_threads(m_nPlaces)
+#pragma omp parallel if (num_qubits_ > omp_threshold_ && m_nPlaces > 1) private(iChunk,i,ib) num_threads(m_nPlaces)
     {
       int iPlace = omp_get_thread_num();
       int iPlaceSrc;
@@ -2210,9 +2218,9 @@ double QubitVectorThrust<data_t>::apply_function(Function func,const reg_t &qubi
 
         //execute kernel
         if(func.Reduction())
-          ret += m_Chunks[iPlace].ExecuteSum(offsets,func,size,(baseChunk << chunkBits),localMask);
+          ret += m_Chunks[iPlace].ExecuteSum(offsets,func,size,(baseChunk << chunkBits),localMask, omp_threshold_ < num_qubits_);
         else
-          m_Chunks[iPlace].Execute(offsets,func,size,(baseChunk << chunkBits),localMask);
+          m_Chunks[iPlace].Execute(offsets,func,size,(baseChunk << chunkBits),localMask, omp_threshold_ < num_qubits_);
 
         //copy back
         for(i=0;i<nChunk;i++){
@@ -4207,7 +4215,7 @@ reg_t QubitVectorThrust<data_t>::sample_measure(const std::vector<double> &rnds)
   placeSum.assign(m_nPlaces+1, 0.0);
 
   //calculate sum of each place
-#pragma omp parallel num_threads(m_nPlaces) private(pVec,size,iPlace)
+#pragma omp parallel if (num_qubits_ > omp_threshold_ && m_nPlaces > 1) num_threads(m_nPlaces) private(pVec,size,iPlace)
   {
     int iDev;
 
@@ -4259,7 +4267,7 @@ reg_t QubitVectorThrust<data_t>::sample_measure(const std::vector<double> &rnds)
 
 
   //now search for the position
-#pragma omp parallel num_threads(m_nPlaces) private(pVec,iPlace,i,size)
+#pragma omp parallel if (num_qubits_ > omp_threshold_ && m_nPlaces > 1) num_threads(m_nPlaces) private(pVec,iPlace,i,size)
   {
     thrust::host_vector<uint_t> vIdx(SHOTS);
     thrust::host_vector<double> vRnd(SHOTS);


### PR DESCRIPTION
…st-omp env

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix performance issues in tests


### Details and comments
Disable OpenMP for low-qubit circuits.
Avoid nested OpenMP if a number of devices is only one.

