### PR TITLE
pulse aspect of configurable backends

### DIFF
--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -179,6 +179,8 @@ class PulseSimulator(AerBackend):
         if system_model is None:
             raise AerError("PulseSimulator requires a system model to run.")
 
+        run_config_new = {**run_config, 'qubit_freq_est': self._defaults.qubit_freq_est}
+
         return pulse_controller(qobj, system_model, run_config)
 
     def _set_option(self, key, value):
@@ -194,11 +196,6 @@ class PulseSimulator(AerBackend):
             setattr(self._configuration, key, value)
             if self._system_model is not None:
                 setattr(self._system_model, key, value)
-        elif key in ['qubit_freq_est', 'meas_freq_est']:
-            # options in both defaults and system model
-            setattr(self._defaults, key, value)
-            if self._system_model is not None:
-                setattr(self._system_model, '_' + key, value)
         # if system model is specified directly
         elif key == 'system_model':
             self._set_system_model(value)
@@ -226,10 +223,6 @@ class PulseSimulator(AerBackend):
                     may result in inconsistencies.''')
 
         self._system_model = system_model
-
-        # extract default information
-        for key in ['qubit_freq_est', 'meas_freq_est']:
-            setattr(self._defaults, key, getattr(self._system_model, '_' + key, None))
 
         # extract config information
         for key in ['dt', 'u_channel_lo']:

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -181,7 +181,7 @@ class PulseSimulator(AerBackend):
         # add qubit_freq_est to the options
         run_config_new = {**run_config, 'qubit_freq_est': self.defaults().qubit_freq_est}
 
-        return pulse_controller(qobj, system_model, run_config)
+        return pulse_controller(qobj, system_model, run_config_new)
 
     def _set_option(self, key, value):
 

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -191,12 +191,12 @@ class PulseSimulator(AerBackend):
             # options in both configuration and system_model
             setattr(self._configuration, key, value)
             if self._system_model is not None:
-                self._system_model.dt = value
+                setattr(self._system_model, key, value)
         elif key in ['qubit_freq_est', 'meas_freq_est']:
             # options in both defaults and system model
             setattr(self._defaults, key, value)
             if self._system_model is not None:
-                setattr(self._system_model, key, value)
+                setattr(self._system_model, '_' + key, value)
         # if system model is specified directly
         elif key == 'system_model':
             if hasattr(self._configuration, 'hamiltonian'):

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -396,7 +396,7 @@ class QasmSimulator(AerBackend):
             'gates': []
         })
 
-        # Statvector methods
+        # Statevector methods
         if method in ['statevector', 'statevector_gpu', 'statevector_thrust']:
             config.description = 'A C++ QasmQobj statevector simulator with noise'
 

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -135,12 +135,12 @@ def pulse_controller(qobj, system_model, backend_options):
     if qubit_lo_freq is None:
         qubit_lo_freq = system_model._qubit_freq_est
 
-    # if still None draw from the Hamiltonian
-    if qubit_lo_freq is None:
+    # if still None, or is the placeholder value draw from the Hamiltonian
+    if qubit_lo_freq is None or qubit_lo_freq == [np.inf]:
         qubit_lo_freq = system_model.hamiltonian.get_qubit_lo_from_drift()
         warn('Warning: qubit_lo_freq was not specified in PulseQobj or in PulseSystemModel, ' +
              'so it is beign automatically determined from the drift Hamiltonian.')
-
+    
     pulse_de_model.freqs = system_model.calculate_channel_frequencies(qubit_lo_freq=qubit_lo_freq)
 
     # ###############################

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -44,7 +44,7 @@ def pulse_controller(qobj, system_model, backend_options):
         ValueError: if input is of incorrect format
         Exception: for invalid ODE options
     """
-
+    import pdb; pdb.set_trace()
     pulse_sim_desc = PulseSimDescription()
     pulse_de_model = PulseInternalDEModel()
 

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -44,7 +44,6 @@ def pulse_controller(qobj, system_model, backend_options):
         ValueError: if input is of incorrect format
         Exception: for invalid ODE options
     """
-    import pdb; pdb.set_trace()
     pulse_sim_desc = PulseSimDescription()
     pulse_de_model = PulseInternalDEModel()
 

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -133,14 +133,15 @@ def pulse_controller(qobj, system_model, backend_options):
 
     # if it wasn't specified in the PulseQobj, draw from system_model
     if qubit_lo_freq is None:
-        qubit_lo_freq = system_model._qubit_freq_est
+        if default_freq != [np.inf]:
+            qubit_lo_freq = backend_options['qubit_freq_est']
 
     # if still None, or is the placeholder value draw from the Hamiltonian
-    if qubit_lo_freq is None or qubit_lo_freq == [np.inf]:
+    if qubit_lo_freq is None:
         qubit_lo_freq = system_model.hamiltonian.get_qubit_lo_from_drift()
-        warn('Warning: qubit_lo_freq was not specified in PulseQobj or in PulseSystemModel, ' +
+        warn('Warning: qubit_lo_freq was not specified in PulseQobj and there is no default, '
              'so it is beign automatically determined from the drift Hamiltonian.')
-    
+
     pulse_de_model.freqs = system_model.calculate_channel_frequencies(qubit_lo_freq=qubit_lo_freq)
 
     # ###############################

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -132,6 +132,7 @@ def pulse_controller(qobj, system_model, backend_options):
 
     # if it wasn't specified in the PulseQobj, draw from system_model
     if qubit_lo_freq is None:
+        default_freq = backend_options.get('qubit_freq_est', [np.inf])
         if default_freq != [np.inf]:
             qubit_lo_freq = backend_options['qubit_freq_est']
 

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -116,9 +116,21 @@ class PulseSystemModel():
         if not config.open_pulse:
             raise AerError('{} is not an open pulse backend'.format(backend))
 
+        return cls.from_config_and_defaults(config, defaults, subsystem_list)
+
+    @classmethod
+    def from_config_and_defaults(cls, configuration, defaults, subsystem_list=None):
+        """Construct a model from configuration and defaults."""
+
         # draw defaults
         qubit_freq_est = getattr(defaults, 'qubit_freq_est', None)
         meas_freq_est = getattr(defaults, 'meas_freq_est', None)
+
+        if qubit_freq_est == [np.inf]:
+            qubit_freq_est = None
+
+        if meas_freq_est == [np.inf]:
+            qubit_freq_est = None
 
         # draw from configuration
         # if no subsystem_list, use all for device

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -56,8 +56,8 @@ class PulseSystemModel():
     """
     def __init__(self,
                  hamiltonian=None,
-                 qubit_freq_est=None,
-                 meas_freq_est=None,
+                 qubit_freq_est=[np.inf],
+                 meas_freq_est=[np.inf],
                  u_channel_lo=None,
                  control_channel_labels=None,
                  subsystem_list=None,

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -31,8 +31,6 @@ class PulseSystemModel():
 
         * ``"hamiltonian"``: a :class:`HamiltonianModel` object representing the
           Hamiltonian of the system.
-        * ``"qubit_freq_est"`` and ``"meas_freq_est"``: optional default values for
-          qubit and measurement frequencies.
         * ``"u_channel_lo"``: A description of :class:`ControlChannel` local oscillator
           frequencies in terms of qubit local oscillator frequencies.
         * ``"control_channel_labels"``: Optional list of identifying information for
@@ -56,8 +54,6 @@ class PulseSystemModel():
     """
     def __init__(self,
                  hamiltonian=None,
-                 qubit_freq_est=[np.inf],
-                 meas_freq_est=[np.inf],
                  u_channel_lo=None,
                  control_channel_labels=None,
                  subsystem_list=None,
@@ -66,10 +62,6 @@ class PulseSystemModel():
 
         Args:
             hamiltonian (HamiltonianModel): The Hamiltonian of the system.
-            qubit_freq_est (list): list of qubit lo frequencies defaults to be used in simulation
-                                   if none are specified in the PulseQobj.
-            meas_freq_est (list): list of qubit meas frequencies defaults to be used in simulation
-                                  if none are specified in the PulseQobj.
             u_channel_lo (list): list of ControlChannel frequency specifications.
             control_channel_labels (list): list of labels for control channels, which can be of
                                            any type.
@@ -78,10 +70,6 @@ class PulseSystemModel():
         Raises:
             AerError: if hamiltonian is not None or a HamiltonianModel
         """
-
-        # default type values
-        self._qubit_freq_est = qubit_freq_est
-        self._meas_freq_est = meas_freq_est
 
         # necessary values
         if hamiltonian is not None and not isinstance(hamiltonian, HamiltonianModel):
@@ -122,16 +110,6 @@ class PulseSystemModel():
     @classmethod
     def from_config_and_defaults(cls, configuration, defaults, subsystem_list=None):
         """Construct a model from configuration and defaults."""
-
-        # draw defaults
-        qubit_freq_est = getattr(defaults, 'qubit_freq_est', None)
-        meas_freq_est = getattr(defaults, 'meas_freq_est', None)
-
-        if qubit_freq_est == [np.inf]:
-            qubit_freq_est = None
-
-        if meas_freq_est == [np.inf]:
-            qubit_freq_est = None
 
         # draw from configuration
         # if no subsystem_list, use all for device
@@ -176,8 +154,6 @@ class PulseSystemModel():
                     control_channel_labels[u_idx] = {'driven_q': drive_idx, 'freq': u_string}
 
         return cls(hamiltonian=hamiltonian,
-                   qubit_freq_est=qubit_freq_est,
-                   meas_freq_est=meas_freq_est,
                    u_channel_lo=u_channel_lo,
                    control_channel_labels=control_channel_labels,
                    subsystem_list=subsystem_list,
@@ -203,8 +179,7 @@ class PulseSystemModel():
 
         Args:
             qubit_lo_freq (list or None): list of qubit linear
-               oscillator drive frequencies. If None these will be calculated
-               using self._qubit_freq_est.
+               oscillator drive frequencies.
 
         Returns:
             OrderedDict: a dictionary of channel frequencies.
@@ -213,10 +188,7 @@ class PulseSystemModel():
             ValueError: If channel or u_channel_lo are invalid.
         """
         if not qubit_lo_freq:
-            if not self._qubit_freq_est:
-                raise ValueError("No qubit_lo_freq to use.")
-
-            qubit_lo_freq = self._qubit_freq_est
+            raise ValueError("qubit_lo_freq is a required function parameter.")
 
         if self.u_channel_lo is None:
             raise ValueError("{} has no u_channel_lo.".format(self.__class__.__name__))

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -99,16 +99,15 @@ class PulseSystemModel():
             raise AerError("{} is not a Qiskit backend".format(backend))
 
         # get relevant information from backend
-        defaults = backend.defaults()
         config = backend.configuration()
 
         if not config.open_pulse:
             raise AerError('{} is not an open pulse backend'.format(backend))
 
-        return cls.from_config_and_defaults(config, defaults, subsystem_list)
+        return cls.from_config(config, subsystem_list)
 
     @classmethod
-    def from_config_and_defaults(cls, configuration, defaults, subsystem_list=None):
+    def from_config(cls, configuration, subsystem_list=None):
         """Construct a model from configuration and defaults."""
 
         # draw from configuration

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -16,6 +16,7 @@
 "System Model class for system specification for the PulseSimulator"
 
 from warnings import warn
+import numpy as np
 from collections import OrderedDict
 from qiskit.providers import BaseBackend
 from qiskit.providers.aer.aererror import AerError
@@ -134,11 +135,11 @@ class PulseSystemModel():
 
         # draw from configuration
         # if no subsystem_list, use all for device
-        subsystem_list = subsystem_list or list(range(config.n_qubits))
-        ham_string = config.hamiltonian
+        subsystem_list = subsystem_list or list(range(configuration.n_qubits))
+        ham_string = configuration.hamiltonian
         hamiltonian = HamiltonianModel.from_dict(ham_string, subsystem_list)
-        u_channel_lo = getattr(config, 'u_channel_lo', None)
-        dt = getattr(config, 'dt', None)
+        u_channel_lo = getattr(configuration, 'u_channel_lo', None)
+        dt = getattr(configuration, 'dt', None)
 
         control_channel_labels = [None] * len(u_channel_lo)
         # populate control_channel_dict

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -278,7 +278,7 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
 
         armonk_sim = PulseSimulator.from_backend(armonk_backend)
 
-        total_samples=250
+        total_samples = 250
         amp = np.pi / (drive_est * dt * total_samples)
 
         sched = self._1Q_schedule(total_samples, amp)
@@ -287,7 +287,7 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
                         meas_level=2,
                         meas_return='single',
                         shots=1)
-        # run and ensure that a pi pulse had been done
+        # run and verify that a pi pulse had been done
         result = armonk_sim.run(qobj).result()
         final_vec = result.get_statevector()
         probabilities = np.abs(final_vec)**2

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -38,7 +38,10 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
 
     def test_bare_instance(self):
         """Test behaviour of PulseSimulator instance with no configuration or defaults."""
-        self.assertTrue(True)
+
+        pulse_sim = PulseSimulator()
+        
+
 
 
 if __name__ == '__main__':

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -294,6 +294,34 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         self.assertTrue(probabilities[0] < 1e-5)
         self.assertTrue(probabilities[1] > 1 - 1e-5)
 
+    def _system_model_1Q(self, omega_0=5., r=0.02):
+        """Constructs a standard model for a 1 qubit system.
+
+        Args:
+            omega_0 (float): qubit frequency
+            r (float): drive strength
+
+        Returns:
+            PulseSystemModel: model for qubit system
+        """
+
+        hamiltonian = {}
+        hamiltonian['h_str'] = [
+            '2*np.pi*omega0*0.5*Z0', '2*np.pi*r*0.5*X0||D0'
+        ]
+        hamiltonian['vars'] = {'omega0': omega_0, 'r': r}
+        hamiltonian['qub'] = {'0': 2}
+        ham_model = HamiltonianModel.from_dict(hamiltonian)
+
+        u_channel_lo = []
+        subsystem_list = [0]
+        dt = 1.
+
+        return PulseSystemModel(hamiltonian=ham_model,
+                                u_channel_lo=u_channel_lo,
+                                subsystem_list=subsystem_list,
+                                dt=dt)
+
     def _1Q_schedule(self, total_samples=100, amp=1., num_acquires=1):
         """Creates a schedule for a single qubit.
 

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -1,0 +1,45 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+PulseSimulator Integration Tests
+"""
+
+import sys
+import unittest
+from test.terra import common
+
+from qiskit.providers.aer.backends import PulseSimulator
+
+from qiskit.compiler import assemble
+from qiskit.providers.aer.pulse.system_models.pulse_system_model import PulseSystemModel
+from qiskit.providers.aer.pulse.system_models.hamiltonian_model import HamiltonianModel
+from qiskit.providers.models.backendconfiguration import UchannelLO
+
+
+class TestConfigPulseSimulator(common.QiskitAerTestCase):
+    r"""PulseSimulator tests."""
+    def setUp(self):
+        """ Set configuration settings for pulse simulator
+        WARNING: We do not support Python 3.5 because the digest algorithm relies on dictionary insertion order.
+        This "feature" was introduced later on Python 3.6 and there's no official support for OrderedDict in the C API so
+        Python 3.5 support has been disabled while looking for a propper fix.
+        """
+        if sys.version_info.major == 3 and sys.version_info.minor == 5:
+            self.skipTest("We don't support Python 3.5 for Pulse simulator")
+
+    def test_bare_instance(self):
+        """Test behaviour of PulseSimulator instance with no configuration or defaults."""
+        self.assertTrue(True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -15,6 +15,7 @@ PulseSimulator Integration Tests
 
 import sys
 import unittest
+import warnings
 from test.terra import common
 
 from qiskit.test.mock.backends.athens.fake_athens import FakeAthens
@@ -37,11 +38,6 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         """
         if sys.version_info.major == 3 and sys.version_info.minor == 5:
             self.skipTest("We don't support Python 3.5 for Pulse simulator")
-
-    def test_bare_instance(self):
-        """Test behaviour of PulseSimulator instance with no configuration or defaults."""
-
-        pass
 
     def test_from_backend_system_model(self):
         """Test that the system model is correctly imported from the backend."""
@@ -106,6 +102,35 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         sim_attr = athens_sim.defaults().meas_freq_est
         model_attr = athens_sim._system_model._meas_freq_est
         self.assertTrue(sim_attr == set_attr and model_attr == set_attr)
+
+    def test_set_meas_levels(self):
+        """Test setting of meas_levels."""
+
+        athens_backend = FakeAthens()
+        athens_sim = PulseSimulator.from_backend(athens_backend)
+
+        # test that a warning is thrown when meas_level 0 is attempted to be set
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            athens_sim.set_options(meas_levels=[0,1,2])
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue('Measurement level 0 not supported' in str(w[-1].message))
+
+        self.assertTrue(athens_sim.configuration().meas_levels == [1, 2])
+
+        athens_sim.set_options(meas_levels=[2])
+        self.assertTrue(athens_sim.configuration().meas_levels == [2])
+
+    def test_set_system_model(self):
+        """Test setting system model."""
+
+        athens_backend = FakeAthens()
+        athens_sim = PulseSimulator.from_backend(athens_backend)
+
+        test_model = 
 
 
 

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -17,6 +17,8 @@ import sys
 import unittest
 from test.terra import common
 
+from qiskit.test.mock.backends.athens.fake_athens import FakeAthens
+
 from qiskit.providers.aer.backends import PulseSimulator
 
 from qiskit.compiler import assemble
@@ -39,8 +41,71 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
     def test_bare_instance(self):
         """Test behaviour of PulseSimulator instance with no configuration or defaults."""
 
-        pulse_sim = PulseSimulator()
-        
+        pass
+
+    def test_from_backend_system_model(self):
+        """Test that the system model is correctly imported from the backend."""
+
+        athens_backend = FakeAthens()
+        athens_sim = PulseSimulator.from_backend(athens_backend)
+
+        # u channel lo
+        athens_attr = athens_backend.configuration().u_channel_lo
+        sim_attr = athens_sim.configuration().u_channel_lo
+        model_attr = athens_sim._system_model.u_channel_lo
+        self.assertTrue(sim_attr == athens_attr and model_attr == athens_attr)
+
+        # dt
+        athens_attr = athens_backend.configuration().dt
+        sim_attr = athens_sim.configuration().dt
+        model_attr = athens_sim._system_model.dt
+        self.assertTrue(sim_attr == athens_attr and model_attr == athens_attr)
+
+        # qubit_freq_est
+        athens_attr = athens_backend.defaults().qubit_freq_est
+        sim_attr = athens_sim.defaults().qubit_freq_est
+        model_attr = athens_sim._system_model._qubit_freq_est
+        self.assertTrue(sim_attr == athens_attr and model_attr == athens_attr)
+
+        # meas_freq_est
+        athens_attr = athens_backend.defaults().meas_freq_est
+        sim_attr = athens_sim.defaults().meas_freq_est
+        model_attr = athens_sim._system_model._meas_freq_est
+        self.assertTrue(sim_attr == athens_attr and model_attr == athens_attr)
+
+    def test_set_system_model_options(self):
+        """Test setting of options that need to be changed in multiple places."""
+
+        athens_backend = FakeAthens()
+        athens_sim = PulseSimulator.from_backend(athens_backend)
+
+        # u channel lo
+        set_attr = [[UchannelLO(0, 1.0 + 0.0j)]]
+        athens_sim.set_options(u_channel_lo=set_attr)
+        sim_attr = athens_sim.configuration().u_channel_lo
+        model_attr = athens_sim._system_model.u_channel_lo
+        self.assertTrue(sim_attr == set_attr and model_attr == set_attr)
+
+        # dt
+        set_attr = 5.
+        athens_sim.set_options(dt=set_attr)
+        sim_attr = athens_sim.configuration().dt
+        model_attr = athens_sim._system_model.dt
+        self.assertTrue(sim_attr == set_attr and model_attr == set_attr)
+
+        # qubit_freq_est
+        set_attr = [5.]
+        athens_sim.set_options(qubit_freq_est=set_attr)
+        sim_attr = athens_sim.defaults().qubit_freq_est
+        model_attr = athens_sim._system_model._qubit_freq_est
+        self.assertTrue(sim_attr == set_attr and model_attr == set_attr)
+
+        # meas_freq_est
+        set_attr = [5.]
+        athens_sim.set_options(meas_freq_est=set_attr)
+        sim_attr = athens_sim.defaults().meas_freq_est
+        model_attr = athens_sim._system_model._meas_freq_est
+        self.assertTrue(sim_attr == set_attr and model_attr == set_attr)
 
 
 

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -50,9 +50,9 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
 
         athens_backend = FakeAthens()
         athens_sim = PulseSimulator.from_backend(athens_backend)
-
+        import pdb; pdb.set_trace()
         self.assertEqual(athens_backend.properties(), athens_sim.properties())
-        self.assertEqual(athens_backend.configuration(), athens_sim.configuration())
+        #self.assertEqual(athens_backend.configuration(), athens_sim.configuration())
         self.assertEqual(athens_backend.defaults(), athens_sim.defaults())
 
 
@@ -73,18 +73,6 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         athens_attr = athens_backend.configuration().dt
         sim_attr = athens_sim.configuration().dt
         model_attr = athens_sim._system_model.dt
-        self.assertTrue(sim_attr == athens_attr and model_attr == athens_attr)
-
-        # qubit_freq_est
-        athens_attr = athens_backend.defaults().qubit_freq_est
-        sim_attr = athens_sim.defaults().qubit_freq_est
-        model_attr = athens_sim._system_model._qubit_freq_est
-        self.assertTrue(sim_attr == athens_attr and model_attr == athens_attr)
-
-        # meas_freq_est
-        athens_attr = athens_backend.defaults().meas_freq_est
-        sim_attr = athens_sim.defaults().meas_freq_est
-        model_attr = athens_sim._system_model._meas_freq_est
         self.assertTrue(sim_attr == athens_attr and model_attr == athens_attr)
 
     def test_set_system_model_options(self):

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -51,9 +51,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         if sys.version_info.major == 3 and sys.version_info.minor == 5:
             self.skipTest("We don't support Python 3.5 for Pulse simulator")
 
-        # Get pulse simulator backend
-        self.backend_sim = PulseSimulator()
-
         self.X = np.array([[0., 1.], [1., 0.]])
         self.Y = np.array([[0., -1j], [1j, 0.]])
         self.Z = np.array([[1., 0.], [0., -1.]])
@@ -73,19 +70,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 100
 
-        # set up constant pulse for doing a pi pulse
-        schedule = self._1Q_constant_sched(total_samples)
-
-        # set up schedule and qobj
-        qobj = assemble([schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[omega_d],
-                        memory_slots=1,
-                        shots=256)
-
         # set up simulator
         system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
@@ -94,6 +78,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         pulse_sim = PulseSimulator(system_model=system_model,
                                    initial_state=y0,
                                    seed=seed)
+
+        # set up constant pulse for doing a pi pulse
+        schedule = self._1Q_constant_sched(total_samples)
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[omega_d],
+                        memory_slots=1,
+                        shots=256)
 
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
@@ -131,19 +126,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01 / 2
         total_samples = 100
 
-        # set up constant pulse for doing a pi pulse
-        schedule = self._1Q_constant_sched(total_samples)
-
-        # set up schedule and qobj
-        qobj = assemble([schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[omega_d],
-                        memory_slots=1,
-                        shots=1)
-
         # set up simulator
         system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
@@ -152,6 +134,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         pulse_sim = PulseSimulator(system_model=system_model,
                                    initial_state=y0,
                                    seed=seed)
+
+        # set up constant pulse for doing a pi pulse
+        schedule = self._1Q_constant_sched(total_samples)
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[omega_d],
+                        memory_slots=1,
+                        shots=1)
 
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
@@ -174,19 +167,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        # set up constant pulse for doing a pi pulse
-        schedule = self._1Q_constant_sched(total_samples)
-
-        # set up schedule and qobj
-        qobj = assemble([schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[omega_d],
-                        memory_slots=1,
-                        shots=256)
-
         # set up simulator
         system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
@@ -195,6 +175,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         pulse_sim = PulseSimulator(system_model=system_model,
                                    initial_state=y0,
                                    seed=seed)
+
+        # set up constant pulse for doing a pi pulse
+        schedule = self._1Q_constant_sched(total_samples)
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[omega_d],
+                        memory_slots=1,
+                        shots=256)
 
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
@@ -232,19 +223,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        # set up constant pulse for doing a pi pulse
-        schedule = self._1Q_constant_sched(total_samples, amp=1j)
-
-        # set up schedule and qobj
-        qobj = assemble([schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[omega_d],
-                        memory_slots=1,
-                        shots=256)
-
         # set up simulator
         system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
@@ -253,6 +231,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         pulse_sim = PulseSimulator(system_model=system_model,
                                    initial_state=y0,
                                    seed=seed)
+
+        # set up constant pulse for doing a pi pulse
+        schedule = self._1Q_constant_sched(total_samples, amp=1j)
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[omega_d],
+                        memory_slots=1,
+                        shots=256)
 
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
@@ -291,18 +280,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 100
 
-        # set up constant pulse for doing a pi pulse
-        schedule = self._1Q_constant_sched(total_samples)
-
-        qobj = assemble([schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[omega_d],
-                        memory_slots=2,
-                        shots=10)
-
         # set up simulator
         system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
@@ -313,6 +290,18 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                    initial_state=y0,
                                    seed=seed,
                                    noise_model=noise_model)
+
+        # set up constant pulse for doing a pi pulse
+        schedule = self._1Q_constant_sched(total_samples)
+
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[omega_d],
+                        memory_slots=2,
+                        shots=10)
 
         result = pulse_sim.run(qobj).result()
 
@@ -335,19 +324,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        # set up constant pulse for doing a pi pulse
-        schedule = self._1Q_constant_sched(total_samples)
-
-        # set up schedule and qobj
-        qobj = assemble([schedule, schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[omega_d],
-                        memory_slots=1,
-                        shots=256)
-
         # set up simulator
         system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
@@ -356,6 +332,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         pulse_sim = PulseSimulator(system_model=system_model,
                                    initial_state=y0,
                                    seed=seed)
+
+        # set up constant pulse for doing a pi pulse
+        schedule = self._1Q_constant_sched(total_samples)
+        qobj = assemble([schedule, schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[omega_d],
+                        memory_slots=1,
+                        shots=256)
 
         result = pulse_sim.run(qobj).result()
 
@@ -383,18 +370,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
             r = 0.01 / scale
             total_samples = 100
 
-            # set up constant pulse for doing a pi pulse
-            schedule = self._1Q_constant_sched(total_samples)
-
-            qobj = assemble([schedule],
-                            backend=self.backend_sim,
-                            meas_level=2,
-                            meas_return='single',
-                            meas_map=[[0]],
-                            qubit_lo_freq=[omega_d],
-                            memory_slots=2,
-                            shots=256)
-
             # set up simulator
             system_model = self._system_model_1Q(omega_0, r)
             system_model.dt = system_model.dt * scale
@@ -404,6 +379,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
             pulse_sim = PulseSimulator(system_model=system_model,
                                        initial_state=y0,
                                        seed=seed)
+
+            # set up constant pulse for doing a pi pulse
+            schedule = self._1Q_constant_sched(total_samples)
+            qobj = assemble([schedule],
+                            backend=pulse_sim,
+                            meas_level=2,
+                            meas_return='single',
+                            meas_map=[[0]],
+                            qubit_lo_freq=[omega_d],
+                            memory_slots=2,
+                            shots=256)
 
             result = pulse_sim.run(qobj).result()
 
@@ -450,19 +436,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         for i in range(num_tests):
             with self.subTest(i=i):
 
-                schedule = self._1Q_constant_sched(total_samples,
-                                                   amp=np.exp(-1j *
-                                                              phase_vals[i]))
-
-                qobj = assemble([schedule],
-                                backend=self.backend_sim,
-                                meas_level=2,
-                                meas_return='single',
-                                meas_map=[[0]],
-                                qubit_lo_freq=[omega_d_vals[i]],
-                                memory_slots=2,
-                                shots=1)
-
                 # set up simulator
                 system_model = self._system_model_1Q(omega_0, r_vals[i])
                 y0 = np.array([1.0, 0.0])
@@ -471,6 +444,19 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                 pulse_sim = PulseSimulator(system_model=system_model,
                                            initial_state=y0,
                                            seed=seed)
+
+                schedule = self._1Q_constant_sched(total_samples,
+                                                   amp=np.exp(-1j *
+                                                              phase_vals[i]))
+
+                qobj = assemble([schedule],
+                                backend=pulse_sim,
+                                meas_level=2,
+                                meas_return='single',
+                                meas_map=[[0]],
+                                qubit_lo_freq=[omega_d_vals[i]],
+                                memory_slots=2,
+                                shots=1)
 
                 result = pulse_sim.run(qobj).result()
                 pulse_sim_yf = result.get_statevector()
@@ -511,24 +497,21 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # Test pi pulse
         r = 0.5 / total_samples
 
-        schedule = self._1Q_constant_sched(total_samples)
-
-        qobj = assemble([schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[freq],
-                        shots=1)
-
-
-
         # set up simulator
         system_model = system_model = self._system_model_3d_oscillator(freq, anharm, r)
         seed = 9000
 
         pulse_sim = PulseSimulator(system_model=system_model,
                                    seed=seed)
+
+        schedule = self._1Q_constant_sched(total_samples)
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[freq],
+                        shots=1)
 
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
@@ -545,17 +528,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # Test some irregular value
         r = 1.49815 / total_samples
-
         schedule = self._1Q_constant_sched(total_samples)
-
-        qobj = assemble([schedule],
-                        backend=self.backend_sim,
-                        meas_level=2,
-                        meas_return='single',
-                        meas_map=[[0]],
-                        qubit_lo_freq=[freq],
-                        shots=1)
-
 
         system_model = self._system_model_3d_oscillator(freq, anharm, r)
         y0 = np.array([0., 0., 1.])
@@ -563,6 +536,13 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         pulse_sim = PulseSimulator(system_model=system_model,
                                    initial_state=y0,
                                    seed=9000)
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=[freq],
+                        shots=1)
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
@@ -584,10 +564,16 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         omega_d0 = 0.
         omega_d1 = 0.
 
-        schedule = self._2Q_constant_sched(total_samples)
+        system_model = self._system_model_2Q(j)
+        y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
 
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+
+        schedule = self._2Q_constant_sched(total_samples)
         qobj = assemble([schedule],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
@@ -595,14 +581,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        system_model = self._system_model_2Q(j)
-        y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
-
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
         result = pulse_sim.run(qobj).result()
-
         pulse_sim_yf = result.get_statevector()
 
         # exact analytic solution
@@ -634,12 +613,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         subsystem_list = [0, 2]
         system_model = self._system_model_3Q(j, subsystem_list=subsystem_list)
 
+        y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
+
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+
         schedule = self._3Q_constant_sched(total_samples,
                                            u_idx=0,
                                            subsystem_list=subsystem_list)
-
         qobj = assemble([schedule],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
@@ -647,11 +631,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
-
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
         result = pulse_sim.run(qobj).result()
 
         pulse_sim_yf = result.get_statevector()
@@ -673,12 +652,15 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         subsystem_list = [1, 2]
         system_model = self._system_model_3Q(j, subsystem_list=subsystem_list)
 
+        y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
+        pulse_sim.set_options(system_model=system_model,
+                              initial_state=y0,
+                              seed=9000)
         schedule = self._3Q_constant_sched(total_samples,
                                            u_idx=1,
                                            subsystem_list=subsystem_list)
-
         qobj = assemble([schedule],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
@@ -686,10 +668,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
-        pulse_sim.set_options(system_model=system_model,
-                              initial_state=y0,
-                              seed=9000)
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
@@ -729,22 +707,21 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                         u_channel_lo=u_channel_lo,
                                         subsystem_list=subsystem_list,
                                         dt=dt)
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=np.array([1., 0.]),
+                                   seed=9000)
 
         # set up schedule and qobj
         total_samples = 50
         schedule = self._1Q_constant_sched(total_samples)
         qobj = assemble([schedule],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
                         qubit_lo_freq=[1.],
                         memory_slots=2,
                         shots=256)
-
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=np.array([1., 0.]),
-                                   seed=9000)
 
         # run simulation
         result = pulse_sim.run(qobj).result()
@@ -772,18 +749,20 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         amp = np.exp(-1j * np.pi / 2)
         schedule = self._1Q_constant_sched(total_samples, amp=amp)
 
+        y0=np.array([1.0, 0.0])
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+
         qobj = assemble([schedule],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=1,
                         meas_return='single',
                         meas_map=[[0]],
                         qubit_lo_freq=[1.],
                         memory_slots=2,
                         shots=shots)
-        y0=np.array([1.0, 0.0])
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
+
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
@@ -848,7 +827,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                     MemorySlot(0)) << schedule.duration
 
                 qobj = assemble([schedule],
-                                backend=self.backend_sim,
+                                backend=pulse_sim,
                                 meas_level=2,
                                 meas_return='single',
                                 meas_map=[[0]],
@@ -911,18 +890,19 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         schedule |= Acquire(total_samples, AcquireChannel(1),
                             MemorySlot(1)) << 3 * total_samples
 
+        y0 = np.array([1., 0., 0., 0.])
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+
         qobj = assemble([schedule],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
                         qubit_lo_freq=q_freqs,
                         memory_slots=2,
                         shots=1000)
-        y0 = np.array([1., 0., 0., 0.])
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
         result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
@@ -972,18 +952,18 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
+        # Result of schedule should be the unitary -1j*Z, so check rotation of an X eigenstate
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=np.array([1., 1.]) / np.sqrt(2))
+
         qobj = assemble([sched],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
                         qubit_lo_freq=[0., 0.],
                         memory_slots=2,
                         shots=1)
-
-        # Result of schedule should be the unitary -1j*Z, so check rotation of an X eigenstate
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=np.array([1., 1.]) / np.sqrt(2))
 
         results = pulse_sim.run(qobj).result()
 
@@ -1003,7 +983,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
         qobj = assemble([sched],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
@@ -1045,19 +1025,18 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
+        y0 = np.array([1., 0])
+
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0)
         qobj = assemble([sched],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
                         qubit_lo_freq=[omega_0],
                         memory_slots=2,
                         shots=1)
-
-        y0 = np.array([1., 0])
-
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0)
         results = pulse_sim.run(qobj).result()
         pulse_sim_yf = results.get_statevector()
 
@@ -1081,7 +1060,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
         qobj = assemble([sched],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
@@ -1128,18 +1107,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
+        y0 = np.array([1., 0.])
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0)
         qobj = assemble([sched],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
                         qubit_lo_freq=[omega_0],
                         memory_slots=2,
                         shots=1)
-
-        y0 = np.array([1., 0.])
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0)
         results = pulse_sim.run(qobj).result()
         pulse_sim_yf = results.get_statevector()
 
@@ -1166,18 +1144,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
+        y0 = np.array([1., 1.]) / np.sqrt(2)
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0)
         qobj = assemble([sched],
-                        backend=self.backend_sim,
+                        backend=pulse_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[[0]],
                         qubit_lo_freq=[omega_0],
                         memory_slots=2,
                         shots=1)
-
-        y0 = np.array([1., 1.]) / np.sqrt(2)
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0)
         results = pulse_sim.run(qobj).result()
         pulse_sim_yf = results.get_statevector()
 

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -509,8 +509,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # Test some irregular value
         r = 1.49815 / total_samples
-        schedule = self._1Q_constant_sched(total_samples)
+        system_model = self._system_model_3d_oscillator(freq, anharm, r)
+        pulse_sim.set_options(system_model=system_model)
 
+        schedule = self._1Q_constant_sched(total_samples)
         qobj = assemble([schedule],
                         backend=pulse_sim,
                         meas_level=2,

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -27,7 +27,7 @@ from qiskit.providers.aer.backends import PulseSimulator
 from qiskit.compiler import assemble
 from qiskit.quantum_info import state_fidelity
 from qiskit.pulse import (Schedule, Play, ShiftPhase, SetPhase, Delay, Acquire,
-                          SamplePulse, DriveChannel, ControlChannel,
+                          Waveform, DriveChannel, ControlChannel,
                           AcquireChannel, MemorySlot)
 from qiskit.providers.aer.pulse.de.DE_Methods import ScipyODE
 from qiskit.providers.aer.pulse.de.DE_Options import DE_Options
@@ -835,7 +835,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
             with self.subTest(gauss_sigma=gauss_sigma):
                 times = 1.0 * np.arange(total_samples)
                 gaussian_samples = np.exp(-times**2 / 2 / gauss_sigma**2)
-                drive_pulse = SamplePulse(gaussian_samples, name='drive_pulse')
+                drive_pulse = Waveform(gaussian_samples, name='drive_pulse')
 
                 # construct schedule
                 schedule = Schedule()
@@ -903,7 +903,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # try some random schedule
         schedule = Schedule()
-        drive_pulse = SamplePulse(np.ones(total_samples))
+        drive_pulse = Waveform(np.ones(total_samples))
         schedule += Play(drive_pulse, DriveChannel(0))
         schedule |= Play(drive_pulse, DriveChannel(1)) << 2 * total_samples
 
@@ -965,12 +965,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # so that the x rotation is transformed into a z rotation.
         # if delays are not handled correctly this process should fail
         sched = Schedule()
-        sched += Play(SamplePulse([0.5]), DriveChannel(1))
+        sched += Play(Waveform([0.5]), DriveChannel(1))
         sched += Delay(1, DriveChannel(1))
-        sched += Play(SamplePulse([-0.5]), DriveChannel(1))
+        sched += Play(Waveform([-0.5]), DriveChannel(1))
 
         sched += Delay(1, DriveChannel(0))
-        sched += Play(SamplePulse([1.]), DriveChannel(0))
+        sched += Play(Waveform([1.]), DriveChannel(0))
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
@@ -998,10 +998,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # verify validity of simulation when no delays included
         sched = Schedule()
-        sched += Play(SamplePulse([0.5]), DriveChannel(1))
-        sched += Play(SamplePulse([-0.5]), DriveChannel(1))
+        sched += Play(Waveform([0.5]), DriveChannel(1))
+        sched += Play(Waveform([-0.5]), DriveChannel(1))
 
-        sched += Play(SamplePulse([1.]), DriveChannel(0))
+        sched += Play(Waveform([1.]), DriveChannel(0))
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
@@ -1040,15 +1040,15 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # Also do it in multiple phase shifts to test accumulation
         sched = Schedule()
         amp1 = 0.12
-        sched += Play(SamplePulse([amp1]), DriveChannel(0))
+        sched += Play(Waveform([amp1]), DriveChannel(0))
         phi1 = 0.12374 * np.pi
         sched += ShiftPhase(phi1, DriveChannel(0))
         amp2 = 0.492
-        sched += Play(SamplePulse([amp2]), DriveChannel(0))
+        sched += Play(Waveform([amp2]), DriveChannel(0))
         phi2 = 0.5839 * np.pi
         sched += ShiftPhase(phi2, DriveChannel(0))
         amp3 = 0.12 + 0.21 * 1j
-        sched += Play(SamplePulse([amp3]), DriveChannel(0))
+        sched += Play(Waveform([amp3]), DriveChannel(0))
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
@@ -1081,11 +1081,11 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # run another schedule with only a single shift phase to verify
         sched = Schedule()
         amp1 = 0.12
-        sched += Play(SamplePulse([amp1]), DriveChannel(0))
+        sched += Play(Waveform([amp1]), DriveChannel(0))
         phi1 = 0.12374 * np.pi
         sched += ShiftPhase(phi1, DriveChannel(0))
         amp2 = 0.492
-        sched += Play(SamplePulse([amp2]), DriveChannel(0))
+        sched += Play(Waveform([amp2]), DriveChannel(0))
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
         qobj = assemble([sched],
@@ -1125,19 +1125,19 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # intermix shift and set phase instructions to verify absolute v.s. relative changes
         sched = Schedule()
         amp1 = 0.12
-        sched += Play(SamplePulse([amp1]), DriveChannel(0))
+        sched += Play(Waveform([amp1]), DriveChannel(0))
         phi1 = 0.12374 * np.pi
         sched += ShiftPhase(phi1, DriveChannel(0))
         amp2 = 0.492
-        sched += Play(SamplePulse([amp2]), DriveChannel(0))
+        sched += Play(Waveform([amp2]), DriveChannel(0))
         phi2 = 0.5839 * np.pi
         sched += SetPhase(phi2, DriveChannel(0))
         amp3 = 0.12 + 0.21 * 1j
-        sched += Play(SamplePulse([amp3]), DriveChannel(0))
+        sched += Play(Waveform([amp3]), DriveChannel(0))
         phi3 = 0.1 * np.pi
         sched += ShiftPhase(phi3, DriveChannel(0))
         amp4 = 0.2 + 0.3 * 1j
-        sched += Play(SamplePulse([amp4]), DriveChannel(0))
+        sched += Play(Waveform([amp4]), DriveChannel(0))
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
@@ -1177,7 +1177,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         sched = Schedule()
         sched += SetPhase(np.pi / 2, DriveChannel(0))
-        sched += Play(SamplePulse(np.ones(100)), DriveChannel(0))
+        sched += Play(Waveform(np.ones(100)), DriveChannel(0))
 
         sched |= Acquire(1, AcquireChannel(0), MemorySlot(0)) << sched.duration
 
@@ -1245,7 +1245,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         """
 
         # set up constant pulse for doing a pi pulse
-        drive_pulse = SamplePulse(amp * np.ones(total_samples))
+        drive_pulse = Waveform(amp * np.ones(total_samples))
         schedule = Schedule()
         schedule |= Play(drive_pulse, DriveChannel(0))
         schedule |= Acquire(total_samples, AcquireChannel(0),
@@ -1295,7 +1295,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         """
 
         # set up constant pulse for doing a pi pulse
-        drive_pulse = SamplePulse(amp * np.ones(total_samples))
+        drive_pulse = Waveform(amp * np.ones(total_samples))
         schedule = Schedule()
         schedule |= Play(drive_pulse, ControlChannel(u_idx))
         schedule |= Acquire(total_samples, AcquireChannel(0),
@@ -1355,7 +1355,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         """
 
         # set up constant pulse for doing a pi pulse
-        drive_pulse = SamplePulse(amp * np.ones(total_samples))
+        drive_pulse = Waveform(amp * np.ones(total_samples))
         schedule = Schedule()
         schedule |= Play(drive_pulse, ControlChannel(u_idx))
         for idx in subsystem_list:

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -70,14 +70,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 100
 
-        # set up simulator
-        system_model = self._system_model_1Q(omega_0, r)
+        # initial state and seed
         y0 = np.array([1.0, 0.0])
         seed = 9000
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=seed)
+        # set up simulator
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
 
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
@@ -90,7 +88,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=256)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
         pulse_sim_yf = result.get_statevector()
 
         # set up and run independent simulation
@@ -126,14 +124,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01 / 2
         total_samples = 100
 
-        # set up simulator
-        system_model = self._system_model_1Q(omega_0, r)
+        # initial state and seed
         y0 = np.array([1.0, 0.0])
         seed = 9000
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=seed)
+        # set up simulator
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
 
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
@@ -146,7 +142,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=1)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
         pulse_sim_yf = result.get_statevector()
 
         # expected final state
@@ -167,14 +163,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        # set up simulator
-        system_model = self._system_model_1Q(omega_0, r)
+        # initial state and seed
         y0 = np.array([1.0, 0.0])
         seed = 9000
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=seed)
+        # set up simulator
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
 
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
@@ -187,7 +181,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=256)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
         pulse_sim_yf = result.get_statevector()
 
         # set up and run independent simulation
@@ -223,14 +217,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        # set up simulator
-        system_model = self._system_model_1Q(omega_0, r)
+        # initial state and seed
         y0 = np.array([1.0, 0.0])
         seed = 9000
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=seed)
+        # set up simulator
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
 
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples, amp=1j)
@@ -243,7 +235,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=256)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
         pulse_sim_yf = result.get_statevector()
 
         # set up and run independent simulation
@@ -280,15 +272,13 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 100
 
-        # set up simulator
-        system_model = self._system_model_1Q(omega_0, r)
+        # initial state, seed, and noise model
         y0 = np.array([1.0, 0.0])
         seed = 9000
         noise_model = {"qubit": {"0": {"Sm": 1.}}}
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=seed,
+        # set up simulator
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r),
                                    noise_model=noise_model)
 
         # set up constant pulse for doing a pi pulse
@@ -303,7 +293,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=10)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
 
         # test results
         # This level of noise is high enough that all counts should yield 0,
@@ -324,14 +314,11 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        # set up simulator
-        system_model = self._system_model_1Q(omega_0, r)
+        # initial state and seed
         y0 = np.array([1.0, 0.0])
         seed = 9000
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=seed)
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
 
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
@@ -344,7 +331,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=256)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
 
         # test results, checking both runs in parallel
         counts = result.get_counts()
@@ -370,15 +357,15 @@ class TestPulseSimulator(common.QiskitAerTestCase):
             r = 0.01 / scale
             total_samples = 100
 
-            # set up simulator
-            system_model = self._system_model_1Q(omega_0, r)
-            system_model.dt = system_model.dt * scale
+            # initial state and seed
             y0 = np.array([1.0, 0.0])
             seed = 9000
 
-            pulse_sim = PulseSimulator(system_model=system_model,
-                                       initial_state=y0,
-                                       seed=seed)
+
+            # set up simulator
+            system_model = self._system_model_1Q(omega_0, r)
+            pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+            pulse_sim.set_options(dt=scale)
 
             # set up constant pulse for doing a pi pulse
             schedule = self._1Q_constant_sched(total_samples)
@@ -391,7 +378,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                             memory_slots=2,
                             shots=256)
 
-            result = pulse_sim.run(qobj).result()
+            result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
 
             pulse_sim_yf = result.get_statevector()
 
@@ -433,22 +420,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r_vals = [3 / total_samples, 5 / total_samples, 0.1]
         phase_vals = [5 * np.pi / 7, 19 * np.pi / 14, np.pi / 4]
 
+        # initial state and seed
+        y0 = np.array([1.0, 0.0])
+        seed = 9000
+
         for i in range(num_tests):
             with self.subTest(i=i):
 
                 # set up simulator
-                system_model = self._system_model_1Q(omega_0, r_vals[i])
-                y0 = np.array([1.0, 0.0])
-                seed = 9000
+                pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r_vals[i]))
 
-                pulse_sim = PulseSimulator(system_model=system_model,
-                                           initial_state=y0,
-                                           seed=seed)
-
-                schedule = self._1Q_constant_sched(total_samples,
-                                                   amp=np.exp(-1j *
-                                                              phase_vals[i]))
-
+                schedule = self._1Q_constant_sched(total_samples, amp=np.exp(-1j *phase_vals[i]))
                 qobj = assemble([schedule],
                                 backend=pulse_sim,
                                 meas_level=2,
@@ -458,7 +440,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                 memory_slots=2,
                                 shots=1)
 
-                result = pulse_sim.run(qobj).result()
+                result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
                 pulse_sim_yf = result.get_statevector()
 
 
@@ -499,10 +481,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # set up simulator
         system_model = system_model = self._system_model_3d_oscillator(freq, anharm, r)
-        seed = 9000
-
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   seed=seed)
+        pulse_sim = PulseSimulator(system_model=system_model)
 
         schedule = self._1Q_constant_sched(total_samples)
         qobj = assemble([schedule],
@@ -523,19 +502,15 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                                 np.array([freq]), samples, 1.)
 
         # test final state
-        self.assertGreaterEqual(state_fidelity(pulse_sim_yf, indep_yf),
-                                1 - 10**-5)
+        self.assertGreaterEqual(state_fidelity(pulse_sim_yf, indep_yf), 1 - 10**-5)
+
+        # test with different input state
+        y0 = np.array([0., 0., 1.])
 
         # Test some irregular value
         r = 1.49815 / total_samples
         schedule = self._1Q_constant_sched(total_samples)
 
-        system_model = self._system_model_3d_oscillator(freq, anharm, r)
-        y0 = np.array([0., 0., 1.])
-
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
         qobj = assemble([schedule],
                         backend=pulse_sim,
                         meas_level=2,
@@ -543,7 +518,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         meas_map=[[0]],
                         qubit_lo_freq=[freq],
                         shots=1)
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0).result()
         pulse_sim_yf = result.get_statevector()
 
         samples = np.ones((total_samples, 1))
@@ -551,8 +526,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                                 np.array([freq]), samples, 1.)
 
         # test final state
-        self.assertGreaterEqual(state_fidelity(pulse_sim_yf, indep_yf),
-                                1 - 10**-5)
+        self.assertGreaterEqual(state_fidelity(pulse_sim_yf, indep_yf), 1 - 10**-5)
 
     def test_2Q_interaction(self):
         r"""Test 2 qubit interaction via controlled operations using u channels."""
@@ -564,12 +538,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         omega_d0 = 0.
         omega_d1 = 0.
 
-        system_model = self._system_model_2Q(j)
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
+        seed=9000
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
+        pulse_sim = PulseSimulator(system_model=self._system_model_2Q(j))
 
         schedule = self._2Q_constant_sched(total_samples)
         qobj = assemble([schedule],
@@ -581,7 +553,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
         pulse_sim_yf = result.get_statevector()
 
         # exact analytic solution
@@ -591,9 +563,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # run with different initial state
         y0 = np.kron(np.array([1., 0.]), np.array([1., 0.]))
-        pulse_sim.set_options(initial_state=y0)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
         pulse_sim_yf = result.get_statevector()
 
         # exact analytic solution
@@ -611,13 +582,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         omega_d = 0.
 
         subsystem_list = [0, 2]
-        system_model = self._system_model_3Q(j, subsystem_list=subsystem_list)
-
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
 
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
+        system_model = self._system_model_3Q(j, subsystem_list=subsystem_list)
+        pulse_sim = PulseSimulator(system_model=system_model)
 
         schedule = self._3Q_constant_sched(total_samples,
                                            u_idx=0,
@@ -631,7 +599,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0).result()
 
         pulse_sim_yf = result.get_statevector()
 
@@ -641,8 +609,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         y0 = np.kron(np.array([1., 0.]), np.array([1., 0.]))
 
-        pulse_sim.set_options(initial_state=y0)
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0).result()
         pulse_sim_yf = result.get_statevector()
 
         yf = expm(-1j * 0.5 * 2 * np.pi * np.kron(self.X, self.Z) / 4) @ y0
@@ -653,9 +620,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         system_model = self._system_model_3Q(j, subsystem_list=subsystem_list)
 
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
-        pulse_sim.set_options(system_model=system_model,
-                              initial_state=y0,
-                              seed=9000)
+        pulse_sim.set_options(system_model=system_model)
         schedule = self._3Q_constant_sched(total_samples,
                                            u_idx=1,
                                            subsystem_list=subsystem_list)
@@ -668,7 +633,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        result = pulse_sim.run(qobj).result()
+        result = pulse_sim.run(qobj, initial_state=y0).result()
         pulse_sim_yf = result.get_statevector()
 
         yf = expm(-1j * 0.5 * 2 * np.pi * np.kron(self.X, self.Z) / 4) @ y0
@@ -803,16 +768,15 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # num of samples gives time
         r = np.pi / total_samples
 
+        # initial state and seed
+        y0 = np.array([1., 0.])
+        seed = 9000
+
         # Test gaussian drive results for a few different sigma
         gauss_sigmas = [total_samples / 6, total_samples / 3, total_samples]
 
-        system_model = self._system_model_1Q(omega_0, r)
-
         # set up pulse simulator
-        y0 = np.array([1., 0.])
-        pulse_sim = PulseSimulator(system_model=system_model,
-                                   initial_state=y0,
-                                   seed=9000)
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
 
         for gauss_sigma in gauss_sigmas:
             with self.subTest(gauss_sigma=gauss_sigma):
@@ -835,7 +799,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                 memory_slots=2,
                                 shots=1)
 
-                result = pulse_sim.run(qobj).result()
+                result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
                 pulse_sim_yf = result.get_statevector()
 
                 # run independent simulation

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -131,8 +131,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01 / 2
         total_samples = 100
 
-        system_model = self._system_model_1Q(omega_0, r)
-
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
 
@@ -146,14 +144,16 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=1)
 
-        # set backend backend_options including initial state
+        # set up simulator
+        system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
-        backend_options = {'seed': 9000, 'initial_state': y0}
+        seed = 9000
 
-        # run simulation
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=seed)
+
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         # expected final state
@@ -174,8 +174,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        system_model = self._system_model_1Q(omega_0, r)
-
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
 
@@ -189,14 +187,16 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=256)
 
-        # set backend backend_options
+        # set up simulator
+        system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
-        backend_options = {'seed': 9000, 'initial_state': y0}
+        seed = 9000
 
-        # run simulation
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=seed)
+
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         # set up and run independent simulation
@@ -232,8 +232,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        system_model = self._system_model_1Q(omega_0, r)
-
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples, amp=1j)
 
@@ -247,14 +245,16 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=256)
 
-        # set backend backend_options
+        # set up simulator
+        system_model = self._system_model_1Q(omega_0, r)
         y0 = np.array([1.0, 0.0])
-        backend_options = {'seed': 9000, 'initial_state': y0}
+        seed = 9000
 
-        # run simulation
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=seed)
+
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         # set up and run independent simulation
@@ -291,8 +291,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 100
 
-        system_model = self._system_model_1Q(omega_0, r)
-
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
 
@@ -305,15 +303,18 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=10)
 
-        # set seed for simulation, and set noise
-        y0 = np.array([1., 0.])
-        backend_options = {'seed': 9000, 'initial_state': y0}
-        backend_options['noise_model'] = {"qubit": {"0": {"Sm": 1.}}}
+        # set up simulator
+        system_model = self._system_model_1Q(omega_0, r)
+        y0 = np.array([1.0, 0.0])
+        seed = 9000
+        noise_model = {"qubit": {"0": {"Sm": 1.}}}
 
-        # run simulation
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=seed,
+                                   noise_model=noise_model)
+
+        result = pulse_sim.run(qobj).result()
 
         # test results
         # This level of noise is high enough that all counts should yield 0,
@@ -334,8 +335,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         r = 0.01
         total_samples = 50
 
-        system_model = self._system_model_1Q(omega_0, r)
-
         # set up constant pulse for doing a pi pulse
         schedule = self._1Q_constant_sched(total_samples)
 
@@ -349,14 +348,16 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=1,
                         shots=256)
 
-        # set backend backend_options
-        y0 = np.array([1., 0.])
-        backend_options = backend_options = {'seed': 9000, 'initial_state': y0}
+        # set up simulator
+        system_model = self._system_model_1Q(omega_0, r)
+        y0 = np.array([1.0, 0.0])
+        seed = 9000
 
-        # run simulation
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=seed)
+
+        result = pulse_sim.run(qobj).result()
 
         # test results, checking both runs in parallel
         counts = result.get_counts()
@@ -382,10 +383,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
             r = 0.01 / scale
             total_samples = 100
 
-            # set up system model and scale time
-            system_model = self._system_model_1Q(omega_0, r)
-            system_model.dt = system_model.dt * scale
-
             # set up constant pulse for doing a pi pulse
             schedule = self._1Q_constant_sched(total_samples)
 
@@ -398,15 +395,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                             memory_slots=2,
                             shots=256)
 
-            # set backend backend_options
-            y0 = np.array([1., 0.])
-            backend_options = {'seed': 9000, 'initial_state': y0}
+            # set up simulator
+            system_model = self._system_model_1Q(omega_0, r)
+            system_model.dt = system_model.dt * scale
+            y0 = np.array([1.0, 0.0])
+            seed = 9000
 
-            # run simulation
-            result = self.backend_sim.run(
-                qobj,
-                system_model=system_model,
-                backend_options=backend_options).result()
+            pulse_sim = PulseSimulator(system_model=system_model,
+                                       initial_state=y0,
+                                       seed=seed)
+
+            result = pulse_sim.run(qobj).result()
 
             pulse_sim_yf = result.get_statevector()
 
@@ -451,7 +450,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         for i in range(num_tests):
             with self.subTest(i=i):
 
-                system_model = self._system_model_1Q(omega_0, r_vals[i])
                 schedule = self._1Q_constant_sched(total_samples,
                                                    amp=np.exp(-1j *
                                                               phase_vals[i]))
@@ -465,15 +463,18 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                 memory_slots=2,
                                 shots=1)
 
-                # Run qobj and compare prop to expected result
-                y0 = np.array([1., 0.])
-                backend_options = {'seed': 9000, 'initial_state': y0}
-                result = self.backend_sim.run(
-                    qobj,
-                    system_model=system_model,
-                    backend_options=backend_options).result()
+                # set up simulator
+                system_model = self._system_model_1Q(omega_0, r_vals[i])
+                y0 = np.array([1.0, 0.0])
+                seed = 9000
 
+                pulse_sim = PulseSimulator(system_model=system_model,
+                                           initial_state=y0,
+                                           seed=seed)
+
+                result = pulse_sim.run(qobj).result()
                 pulse_sim_yf = result.get_statevector()
+
 
                 # set up and run independent simulation
                 samples = np.exp(-1j * phase_vals[i]) * np.ones(
@@ -510,7 +511,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # Test pi pulse
         r = 0.5 / total_samples
 
-        system_model = self._system_model_3d_oscillator(freq, anharm, r)
         schedule = self._1Q_constant_sched(total_samples)
 
         qobj = assemble([schedule],
@@ -520,11 +520,17 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         meas_map=[[0]],
                         qubit_lo_freq=[freq],
                         shots=1)
-        backend_options = {'seed': 9000}
 
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+
+
+        # set up simulator
+        system_model = system_model = self._system_model_3d_oscillator(freq, anharm, r)
+        seed = 9000
+
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   seed=seed)
+
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         # set up and run independent simulation
@@ -540,7 +546,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # Test some irregular value
         r = 1.49815 / total_samples
 
-        system_model = self._system_model_3d_oscillator(freq, anharm, r)
         schedule = self._1Q_constant_sched(total_samples)
 
         qobj = assemble([schedule],
@@ -551,12 +556,14 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         qubit_lo_freq=[freq],
                         shots=1)
 
-        y0 = np.array([0., 0., 1.])
-        backend_options = {'seed': 9000, 'initial_state': y0}
 
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        system_model = self._system_model_3d_oscillator(freq, anharm, r)
+        y0 = np.array([0., 0., 1.])
+
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         samples = np.ones((total_samples, 1))
@@ -577,8 +584,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         omega_d0 = 0.
         omega_d1 = 0.
 
-        system_model = self._system_model_2Q(j)
-
         schedule = self._2Q_constant_sched(total_samples)
 
         qobj = assemble([schedule],
@@ -590,12 +595,14 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
+        system_model = self._system_model_2Q(j)
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
-        backend_options = {'seed': 9000, 'initial_state': y0}
 
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+        result = pulse_sim.run(qobj).result()
+
         pulse_sim_yf = result.get_statevector()
 
         # exact analytic solution
@@ -605,11 +612,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # run with different initial state
         y0 = np.kron(np.array([1., 0.]), np.array([1., 0.]))
-        backend_options = {'seed': 9000, 'initial_state': y0}
+        pulse_sim.set_options(initial_state=y0)
 
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         # exact analytic solution
@@ -643,11 +648,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         shots=1)
 
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
-        backend_options = {'seed': 9000, 'initial_state': y0}
 
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+        result = pulse_sim.run(qobj).result()
+
         pulse_sim_yf = result.get_statevector()
 
         yf = expm(-1j * 0.5 * 2 * np.pi * np.kron(self.X, self.Z) / 4) @ y0
@@ -655,11 +661,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         self.assertGreaterEqual(state_fidelity(pulse_sim_yf, yf), 1 - (10**-5))
 
         y0 = np.kron(np.array([1., 0.]), np.array([1., 0.]))
-        backend_options = {'seed': 9000, 'initial_state': y0}
 
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim.set_options(initial_state=y0)
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         yf = expm(-1j * 0.5 * 2 * np.pi * np.kron(self.X, self.Z) / 4) @ y0
@@ -683,11 +687,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         shots=1)
 
         y0 = np.kron(np.array([1., 0.]), np.array([0., 1.]))
-        backend_options = {'seed': 9000, 'initial_state': y0}
-
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim.set_options(system_model=system_model,
+                              initial_state=y0,
+                              seed=9000)
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         yf = expm(-1j * 0.5 * 2 * np.pi * np.kron(self.X, self.Z) / 4) @ y0
@@ -695,11 +698,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         self.assertGreaterEqual(state_fidelity(pulse_sim_yf, yf), 1 - (10**-5))
 
         y0 = np.kron(np.array([1., 0.]), np.array([1., 0.]))
-        backend_options = {'seed': 9000, 'initial_state': y0}
+        pulse_sim.set_options(initial_state=y0)
 
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         yf = expm(-1j * 0.5 * 2 * np.pi * np.kron(self.X, self.Z) / 4) @ y0
@@ -741,13 +742,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=256)
 
-        # set backend backend_options
-        backend_options = {'seed': 9000, 'initial_state': np.array([1., 0.])}
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=np.array([1., 0.]),
+                                   seed=9000)
 
         # run simulation
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        result = pulse_sim.run(qobj).result()
 
         # test results
         counts = result.get_counts()
@@ -780,13 +780,11 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         qubit_lo_freq=[1.],
                         memory_slots=2,
                         shots=shots)
-
-        # set backend backend_options
-        y0 = np.array([1.0, 0.0])
-        backend_options = {'seed': 9000, 'initial_state': y0}
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        y0=np.array([1.0, 0.0])
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         samples = amp * np.ones((total_samples, 1))
@@ -831,6 +829,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         system_model = self._system_model_1Q(omega_0, r)
 
+        # set up pulse simulator
+        y0 = np.array([1., 0.])
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+
         for gauss_sigma in gauss_sigmas:
             with self.subTest(gauss_sigma=gauss_sigma):
                 times = 1.0 * np.arange(total_samples)
@@ -851,13 +855,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                 qubit_lo_freq=[omega_d],
                                 memory_slots=2,
                                 shots=1)
-                y0 = np.array([1., 0.])
-                backend_options = {'seed': 9000, 'initial_state': y0}
 
-                result = self.backend_sim.run(
-                    qobj,
-                    system_model=system_model,
-                    backend_options=backend_options).result()
+                result = pulse_sim.run(qobj).result()
                 pulse_sim_yf = result.get_statevector()
 
                 # run independent simulation
@@ -921,11 +920,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1000)
         y0 = np.array([1., 0., 0., 0.])
-        backend_options = {'seed': 9000, 'initial_state': y0}
-
-        result = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+        result = pulse_sim.run(qobj).result()
         pulse_sim_yf = result.get_statevector()
 
         # set up and run independent simulation
@@ -984,11 +982,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         shots=1)
 
         # Result of schedule should be the unitary -1j*Z, so check rotation of an X eigenstate
-        backend_options = {'initial_state': np.array([1., 1.]) / np.sqrt(2)}
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=np.array([1., 1.]) / np.sqrt(2))
 
-        results = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        results = pulse_sim.run(qobj).result()
 
         statevector = results.get_statevector()
         expected_vector = np.array([-1j, 1j]) / np.sqrt(2)
@@ -1014,11 +1011,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        backend_options = {'initial_state': np.array([1., 1.]) / np.sqrt(2)}
-
-        results = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        results = pulse_sim.run(qobj).result()
 
         statevector = results.get_statevector()
         U = expm(1j * np.pi * self.Y / 4) @ expm(-1j * np.pi *
@@ -1062,11 +1055,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         shots=1)
 
         y0 = np.array([1., 0])
-        backend_options = {'initial_state': y0}
 
-        results = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0)
+        results = pulse_sim.run(qobj).result()
         pulse_sim_yf = results.get_statevector()
 
         #run independent simulation
@@ -1097,12 +1089,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1)
 
-        y0 = np.array([1., 0])
-        backend_options = {'initial_state': y0}
-
-        results = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        results = pulse_sim.run(qobj).result()
         pulse_sim_yf = results.get_statevector()
 
         #run independent simulation
@@ -1151,11 +1138,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         shots=1)
 
         y0 = np.array([1., 0.])
-        backend_options = {'initial_state': y0}
-
-        results = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0)
+        results = pulse_sim.run(qobj).result()
         pulse_sim_yf = results.get_statevector()
 
         #run independent simulation
@@ -1191,11 +1176,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         shots=1)
 
         y0 = np.array([1., 1.]) / np.sqrt(2)
-        backend_options = {'initial_state': y0}
-
-        results = self.backend_sim.run(
-            qobj, system_model=system_model,
-            backend_options=backend_options).result()
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0)
+        results = pulse_sim.run(qobj).result()
         pulse_sim_yf = results.get_statevector()
 
         #run independent simulation

--- a/test/terra/pulse/test_system_models.py
+++ b/test/terra/pulse/test_system_models.py
@@ -33,7 +33,6 @@ class BaseTestPulseSystemModel(QiskitAerTestCase):
     """Tests for PulseSystemModel"""
 
     def setUp(self):
-        self._default_qubit_lo_freq = [4.9, 5.0]
         self._u_channel_lo = []
         self._u_channel_lo.append([UchannelLO(0, 1.0+0.0j)])
         self._u_channel_lo.append([UchannelLO(0, -1.0+0.0j), UchannelLO(1, 1.0+0.0j)])
@@ -62,7 +61,6 @@ class BaseTestPulseSystemModel(QiskitAerTestCase):
         dt = 1.
 
         return PulseSystemModel(hamiltonian=ham_model,
-                                qubit_freq_est=self._default_qubit_lo_freq,
                                 u_channel_lo=self._u_channel_lo,
                                 subsystem_list=subsystem_list,
                                 dt=dt)
@@ -111,27 +109,6 @@ class TestPulseSystemModel(BaseTestPulseSystemModel):
                     {'driven_q': 0, 'freq': '(-1+0j)q0 + (1+0j)q1'}]
 
         self.assertEqual(system_model.control_channel_labels, expected)
-
-    def test_qubit_lo_default(self):
-        """Test drawing of defaults form a backend."""
-        test_model = self._simple_system_model()
-        default_qubit_lo_freq = self._default_qubit_lo_freq
-        default_u_lo_freq = self._compute_u_lo_freqs(default_qubit_lo_freq)
-
-        # test output of default qubit_lo_freq
-        freqs = test_model.calculate_channel_frequencies()
-        self.assertAlmostEqual(freqs['D0'], default_qubit_lo_freq[0])
-        self.assertAlmostEqual(freqs['D1'], default_qubit_lo_freq[1])
-        self.assertAlmostEqual(freqs['U0'], default_u_lo_freq[0])
-        self.assertAlmostEqual(freqs['U1'], default_u_lo_freq[1])
-
-        # test defaults again, but with non-default hamiltonian
-        test_model = self._simple_system_model(v0=5.1, v1=4.9, j=0.02)
-        freqs = test_model.calculate_channel_frequencies()
-        self.assertAlmostEqual(freqs['D0'], default_qubit_lo_freq[0])
-        self.assertAlmostEqual(freqs['D1'], default_qubit_lo_freq[1])
-        self.assertAlmostEqual(freqs['U0'], default_u_lo_freq[0])
-        self.assertAlmostEqual(freqs['U1'], default_u_lo_freq[1])
 
     def test_qubit_lo_from_hamiltonian(self):
         """Test computation of qubit_lo_freq from the hamiltonian itself."""

--- a/tools/verify_wheels.py
+++ b/tools/verify_wheels.py
@@ -15,7 +15,7 @@ from qiskit import QuantumCircuit
 from qiskit import QuantumRegister
 
 from qiskit.providers.aer.pulse.system_models.duffing_model_generators import duffing_system_model
-from qiskit.pulse import (Schedule, Play, Acquire, SamplePulse, DriveChannel, AcquireChannel,
+from qiskit.pulse import (Schedule, Play, Acquire, Waveform, DriveChannel, AcquireChannel,
                           MemorySlot)
 
 from qiskit.providers.aer import QasmSimulator
@@ -423,7 +423,7 @@ def model_and_pi_schedule():
                                  dt=1.0)
 
     # note: parameters set so that area under curve is 1/4
-    sample_pulse = SamplePulse(np.ones(50))
+    sample_pulse = Waveform(np.ones(50))
 
     # construct schedule
     schedule = Schedule(name='test_sched')


### PR DESCRIPTION
### Summary

Currents status:
- Behaviour with respect to system model
   - I've elevated the system model storage in the `PulseSimulator` backend to a private attribute - as opposed to something just in `run_config` - to distinguish between when a system model is being passed as an argument to `run` and when it is the internally stored one. (Also even if we totally get rid of specifying the system model through backend options when `run` is called, the system model needs to be interacted with enough that it is more convenient to have it as an attribute than to check if its in the dictionary every time.)
    - At instantiation of the `PulseSimulator`, the system model could potentially be derived from `configuration` or from a directly supplied `system_model`. If both are supplied and the `configuration` contains a Hamiltonian, the user-passed `system_model` takes precedence, and a warning is issued notifying the user of this. 
    - User modifications to `configuration` and `system_model` after instantiation could result in inconsistencies between the two. The behaviour I've settled on is:
        - If the user directly updates `system_model`, it checks if the `configuration` has a Hamiltonian, and if it does, it issues a warning that inconsistencies may result. (It is unclear how to update the Hamiltonian description from an updated system model and I think is more trouble than it's worth.)
        - If the user updates the Hamiltonian in the configuration, the `system_model` will be reconstructed from it. (There are no inconsistencies in this case.) **Note: I still need to actually implement this.**
- I've updated all pulse simulator tests to use the new interface (i.e. instantiate with all settings and then just call `run`)
- As an aside I've also updated all tests to use `Waveform` instead of `SamplePulse`


To do:
- Implement special behaviour for updating Hamiltonian in the config
- Implement special behaviour for updating defaults in the system model (maybe these should be moved out of the `PulseSystemModel` to the configurable backend itself anyway?)
- Figure out validation warnings/errors from latest version of `terra`
    - In updated tests I'm getting `qiskit-terra/qiskit/compiler/assemble.py:320: RuntimeWarning: Dynamic rep rates not supported on this backend. rep_time will be used instead of rep_delay.`
    - The `from_backend` tutorial was working with a previous version of terra but now gives crazy validation errors
- Add proper testing of configurable backend behaviour generally