### PR TITLE
Use virtual functions with transformer classes

### DIFF
--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -38,7 +38,6 @@
 
 namespace AER {
 namespace QV {
-
 template <typename T> using cvector_t = std::vector<std::complex<T>>;
 
 //============================================================================
@@ -56,6 +55,7 @@ template <typename T> using cvector_t = std::vector<std::complex<T>>;
 
 template <typename data_t = double>
 class QubitVector {
+    std::unique_ptr<Transformer<std::complex<data_t>*, data_t>> transformer_;
 
 public:
 
@@ -566,6 +566,9 @@ template <typename data_t>
 QubitVector<data_t>::QubitVector(size_t num_qubits)
   : num_qubits_(0), data_(nullptr), checkpoint_(0) {
     set_num_qubits(num_qubits);
+
+    transformer_ = is_avx2_supported() ? std::make_unique<TransformerAVX2<std::complex<data_t>*, data_t>>()
+        : std::make_unique<Transformer<std::complex<data_t>*, data_t>>();
   }
 
 template <typename data_t>
@@ -961,12 +964,7 @@ QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
 template <typename data_t>
 void QubitVector<data_t>::apply_matrix(const reg_t &qubits,
                                        const cvector_t<double> &mat) {
-  // TODO: Move transformer initialization somewhere else
-  if (is_avx2_supported()) {
-    TransformerAVX2<data_t>::apply_matrix(data_, data_size_, omp_threads_managed(), qubits, mat);
-  } else {
-    Transformer<data_t>::apply_matrix(data_, data_size_, omp_threads_managed(), qubits, mat);
-  }
+    transformer_->apply_matrix(data_, data_size_, omp_threads_managed(), qubits, mat);
 }
 
 template <typename data_t>
@@ -1006,7 +1004,7 @@ void QubitVector<data_t>::apply_multiplexer(const reg_t &control_qubits,
 template <typename data_t>
 void QubitVector<data_t>::apply_diagonal_matrix(const reg_t &qubits,
                                                 const cvector_t<double> &diag) {
-  Transformer<data_t>::apply_diagonal_matrix(data_, data_size_, omp_threads_managed(), qubits, diag);
+    transformer_->apply_diagonal_matrix(data_, data_size_, omp_threads_managed(), qubits, diag);
 }
 
 template <typename data_t>

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -336,7 +336,12 @@ protected:
     return (num_qubits_ > omp_threshold_ && omp_threads_ > 1) ? omp_threads_: 1;
   }
 
-  //-----------------------------------------------------------------------
+  void set_transformer_method(){
+    transformer_ = is_avx2_supported() ? std::make_unique<TransformerAVX2<std::complex<data_t>*, data_t>>()
+                                       : std::make_unique<Transformer<std::complex<data_t>*, data_t>>();
+  }
+
+    //-----------------------------------------------------------------------
   // Error Messages
   //-----------------------------------------------------------------------
 
@@ -566,9 +571,7 @@ template <typename data_t>
 QubitVector<data_t>::QubitVector(size_t num_qubits)
   : num_qubits_(0), data_(nullptr), checkpoint_(0) {
     set_num_qubits(num_qubits);
-
-    transformer_ = is_avx2_supported() ? std::make_unique<TransformerAVX2<std::complex<data_t>*, data_t>>()
-        : std::make_unique<Transformer<std::complex<data_t>*, data_t>>();
+    set_transformer_method();
   }
 
 template <typename data_t>

--- a/src/simulators/statevector/transformer.hpp
+++ b/src/simulators/statevector/transformer.hpp
@@ -28,6 +28,8 @@ template <typename Container, typename data_t = double> class Transformer {
   // TODO: This class should have the indexes.hpp moved inside it
 
 public:
+
+  virtual ~Transformer() {}
   //-----------------------------------------------------------------------
   // Apply Matrices
   //-----------------------------------------------------------------------

--- a/src/simulators/statevector/transformer.hpp
+++ b/src/simulators/statevector/transformer.hpp
@@ -39,13 +39,13 @@ public:
   // matrix.
 
   virtual void apply_matrix(Container &data, size_t data_size, int threads,
-                           const reg_t &qubits, const cvector_t<double> &mat);
+                           const reg_t &qubits, const cvector_t<double> &mat) const;
 
   // Apply a N-qubit diagonal matrix to a array container
   // The matrix is input as vector of the matrix diagonal.
   virtual void apply_diagonal_matrix(Container &data, size_t data_size,
                                     int threads, const reg_t &qubits,
-                                    const cvector_t<double> &diag);
+                                    const cvector_t<double> &diag) const;
 
 protected:
   // Apply a N-qubit matrix to the state vector.
@@ -53,20 +53,20 @@ protected:
   // matrix.
   template <size_t N>
   void apply_matrix_n(Container &data, size_t data_size, int threads,
-                             const reg_t &qubits, const cvector_t<double> &mat);
+                             const reg_t &qubits, const cvector_t<double> &mat) const;
 
   // Specialized single qubit apply matrix function
   void apply_matrix_1(Container &data, size_t data_size, int threads,
-                             const uint_t qubit, const cvector_t<double> &mat);
+                             const uint_t qubit, const cvector_t<double> &mat) const;
 
   // Specialized single qubit apply matrix function
   void apply_diagonal_matrix_1(Container &data, size_t data_size,
                                       int threads, const uint_t qubit,
-                                      const cvector_t<double> &mat);
+                                      const cvector_t<double> &mat) const;
 
   // Convert a matrix to a different type
   // TODO: this makes an unnecessary copy when data_t = double.
-  cvector_t<data_t> convert(const cvector_t<double> &v);
+  cvector_t<data_t> convert(const cvector_t<double> &v) const;
 };
 
 /*******************************************************************************
@@ -76,7 +76,7 @@ protected:
  ******************************************************************************/
 
 template <typename Container, typename data_t>
-cvector_t<data_t> Transformer<Container, data_t>::convert(const cvector_t<double> &v) {
+cvector_t<data_t> Transformer<Container, data_t>::convert(const cvector_t<double> &v) const {
   cvector_t<data_t> ret(v.size());
   for (size_t i = 0; i < v.size(); ++i)
     ret[i] = v[i];
@@ -86,7 +86,7 @@ cvector_t<data_t> Transformer<Container, data_t>::convert(const cvector_t<double
 template <typename Container, typename data_t>
 void Transformer<Container, data_t>::apply_matrix(Container &data, size_t data_size,
                                        int threads, const reg_t &qubits,
-                                       const cvector_t<double> &mat) {
+                                       const cvector_t<double> &mat) const {
   // Static array optimized lambda functions
   switch (qubits.size()) {
     case 1:
@@ -140,7 +140,7 @@ template <typename Container, typename data_t>
 template <size_t N>
 void Transformer<Container, data_t>::apply_matrix_n(Container &data, size_t data_size,
                                          int threads, const reg_t &qs,
-                                         const cvector_t<double> &mat) {
+                                         const cvector_t<double> &mat) const {
   const size_t DIM = 1ULL << N;
   auto func = [&](const areg_t<1UL << N> &inds,
                   const cvector_t<data_t> &_mat) -> void {
@@ -163,7 +163,7 @@ void Transformer<Container, data_t>::apply_matrix_n(Container &data, size_t data
 template <typename Container, typename data_t>
 void Transformer<Container, data_t>::apply_matrix_1(Container &data, size_t data_size,
                                          int threads, const uint_t qubit,
-                                         const cvector_t<double> &mat) {
+                                         const cvector_t<double> &mat) const {
 
   // Check if matrix is diagonal and if so use optimized lambda
   if (mat[1] == 0.0 && mat[2] == 0.0) {
@@ -232,7 +232,7 @@ template <typename Container, typename data_t>
 void Transformer<Container, data_t>::apply_diagonal_matrix(Container &data,
                                                 size_t data_size, int threads,
                                                 const reg_t &qubits,
-                                                const cvector_t<double> &diag) {
+                                                const cvector_t<double> &diag) const {
   if (qubits.size() == 1) {
     apply_diagonal_matrix_1(data, data_size, threads, qubits[0], diag);
     return;
@@ -256,9 +256,9 @@ void Transformer<Container, data_t>::apply_diagonal_matrix(Container &data,
 }
 
 template <typename Container, typename data_t>
-void Transformer<Container, data_t>::apply_diagonal_matrix_1(
+void Transformer<Container, data_t>::apply_diagonal_matrix_1 (
     Container &data, size_t data_size, int threads, const uint_t qubit,
-    const cvector_t<double> &diag) {
+    const cvector_t<double> &diag) const {
   // TODO: This should be changed so it isn't checking doubles with ==
   if (diag[0] == 1.0) { // [[1, 0], [0, z]] matrix
     if (diag[1] == 1.0)

--- a/src/simulators/statevector/transformer.hpp
+++ b/src/simulators/statevector/transformer.hpp
@@ -23,7 +23,7 @@ namespace QV {
 
 template <typename T> using cvector_t = std::vector<std::complex<T>>;
 
-template <typename data_t = double> class Transformer {
+template <typename Container, typename data_t = double> class Transformer {
 
   // TODO: This class should have the indexes.hpp moved inside it
 
@@ -35,14 +35,13 @@ public:
   // Apply a N-qubit matrix to the state vector.
   // The matrix is input as vector of the column-major vectorized N-qubit
   // matrix.
-  template <typename Container>
-  static void apply_matrix(Container &data, size_t data_size, int threads,
+
+  virtual void apply_matrix(Container &data, size_t data_size, int threads,
                            const reg_t &qubits, const cvector_t<double> &mat);
 
   // Apply a N-qubit diagonal matrix to a array container
   // The matrix is input as vector of the matrix diagonal.
-  template <typename Container>
-  static void apply_diagonal_matrix(Container &data, size_t data_size,
+  virtual void apply_diagonal_matrix(Container &data, size_t data_size,
                                     int threads, const reg_t &qubits,
                                     const cvector_t<double> &diag);
 
@@ -50,24 +49,22 @@ protected:
   // Apply a N-qubit matrix to the state vector.
   // The matrix is input as vector of the column-major vectorized N-qubit
   // matrix.
-  template <size_t N, typename Container>
-  static void apply_matrix_n(Container &data, size_t data_size, int threads,
+  template <size_t N>
+  void apply_matrix_n(Container &data, size_t data_size, int threads,
                              const reg_t &qubits, const cvector_t<double> &mat);
 
   // Specialized single qubit apply matrix function
-  template <typename Container>
-  static void apply_matrix_1(Container &data, size_t data_size, int threads,
+  void apply_matrix_1(Container &data, size_t data_size, int threads,
                              const uint_t qubit, const cvector_t<double> &mat);
 
   // Specialized single qubit apply matrix function
-  template <typename Container>
-  static void apply_diagonal_matrix_1(Container &data, size_t data_size,
+  void apply_diagonal_matrix_1(Container &data, size_t data_size,
                                       int threads, const uint_t qubit,
                                       const cvector_t<double> &mat);
 
   // Convert a matrix to a different type
   // TODO: this makes an unnecessary copy when data_t = double.
-  static cvector_t<data_t> convert(const cvector_t<double> &v);
+  cvector_t<data_t> convert(const cvector_t<double> &v);
 };
 
 /*******************************************************************************
@@ -76,17 +73,16 @@ protected:
  *
  ******************************************************************************/
 
-template <typename data_t>
-cvector_t<data_t> Transformer<data_t>::convert(const cvector_t<double> &v) {
+template <typename Container, typename data_t>
+cvector_t<data_t> Transformer<Container, data_t>::convert(const cvector_t<double> &v) {
   cvector_t<data_t> ret(v.size());
   for (size_t i = 0; i < v.size(); ++i)
     ret[i] = v[i];
   return ret;
 }
 
-template <typename data_t>
-template <typename Container>
-void Transformer<data_t>::apply_matrix(Container &data, size_t data_size,
+template <typename Container, typename data_t>
+void Transformer<Container, data_t>::apply_matrix(Container &data, size_t data_size,
                                        int threads, const reg_t &qubits,
                                        const cvector_t<double> &mat) {
   // Static array optimized lambda functions
@@ -138,9 +134,9 @@ void Transformer<data_t>::apply_matrix(Container &data, size_t data_size,
   }
 }
 
-template <typename data_t>
-template <size_t N, typename Container>
-void Transformer<data_t>::apply_matrix_n(Container &data, size_t data_size,
+template <typename Container, typename data_t>
+template <size_t N>
+void Transformer<Container, data_t>::apply_matrix_n(Container &data, size_t data_size,
                                          int threads, const reg_t &qs,
                                          const cvector_t<double> &mat) {
   const size_t DIM = 1ULL << N;
@@ -162,9 +158,8 @@ void Transformer<data_t>::apply_matrix_n(Container &data, size_t data_size,
   apply_lambda(0, data_size, threads, func, qubits, convert(mat));
 }
 
-template <typename data_t>
-template <typename Container>
-void Transformer<data_t>::apply_matrix_1(Container &data, size_t data_size,
+template <typename Container, typename data_t>
+void Transformer<Container, data_t>::apply_matrix_1(Container &data, size_t data_size,
                                          int threads, const uint_t qubit,
                                          const cvector_t<double> &mat) {
 
@@ -231,9 +226,8 @@ void Transformer<data_t>::apply_matrix_1(Container &data, size_t data_size,
   apply_lambda(0, data_size, threads, func, qubits, convert(mat));
 }
 
-template <typename data_t>
-template <typename Container>
-void Transformer<data_t>::apply_diagonal_matrix(Container &data,
+template <typename Container, typename data_t>
+void Transformer<Container, data_t>::apply_diagonal_matrix(Container &data,
                                                 size_t data_size, int threads,
                                                 const reg_t &qubits,
                                                 const cvector_t<double> &diag) {
@@ -259,9 +253,8 @@ void Transformer<data_t>::apply_diagonal_matrix(Container &data,
                convert(diag));
 }
 
-template <typename data_t>
-template <typename Container>
-void Transformer<data_t>::apply_diagonal_matrix_1(
+template <typename Container, typename data_t>
+void Transformer<Container, data_t>::apply_diagonal_matrix_1(
     Container &data, size_t data_size, int threads, const uint_t qubit,
     const cvector_t<double> &diag) {
   // TODO: This should be changed so it isn't checking doubles with ==
@@ -373,9 +366,6 @@ void Transformer<data_t>::apply_diagonal_matrix_1(
                  convert(diag));
   }
 }
-
-template class Transformer<double>;
-template class Transformer<float>;
 
 //------------------------------------------------------------------------------
 } // end namespace QV

--- a/src/simulators/statevector/transformer_avx2.hpp
+++ b/src/simulators/statevector/transformer_avx2.hpp
@@ -22,9 +22,9 @@
 namespace AER {
 namespace QV {
 
-template <typename data_t = double>
-class TransformerAVX2 : public Transformer<data_t> {
-  using Base = Transformer<data_t>;
+template <typename Container, typename data_t = double>
+class TransformerAVX2 : public Transformer<Container, data_t> {
+  using Base = Transformer<Container, data_t>;
 
 public:
   //-----------------------------------------------------------------------
@@ -34,8 +34,7 @@ public:
   // Apply a N-qubit matrix to the state vector.
   // The matrix is input as vector of the column-major vectorized N-qubit
   // matrix.
-  template <typename Container>
-  static void apply_matrix(Container &data, size_t data_size, int threads,
+  void apply_matrix(Container &data, size_t data_size, int threads,
                            const reg_t &qubits, const cvector_t<double> &mat);
 };
 
@@ -49,9 +48,8 @@ public:
 // so it can compile, as this class won't be used
 #if defined(_MSC_VER) || defined(GNUC_AVX2)
 
-template <typename data_t>
-template <typename Container>
-void TransformerAVX2<data_t>::apply_matrix(Container &data, size_t data_size,
+template <typename Container, typename data_t>
+void TransformerAVX2<Container, data_t>::apply_matrix(Container &data, size_t data_size,
                                            int threads, const reg_t &qubits,
                                            const cvector_t<double> &mat) {
 
@@ -71,9 +69,6 @@ void TransformerAVX2<data_t>::apply_matrix(Container &data, size_t data_size,
 }
 
 #endif // AVX2 Code
-
-template class TransformerAVX2<double>;
-template class TransformerAVX2<float>;
 
 //------------------------------------------------------------------------------
 } // end namespace QV

--- a/src/simulators/statevector/transformer_avx2.hpp
+++ b/src/simulators/statevector/transformer_avx2.hpp
@@ -35,7 +35,7 @@ public:
   // The matrix is input as vector of the column-major vectorized N-qubit
   // matrix.
   void apply_matrix(Container &data, size_t data_size, int threads,
-                           const reg_t &qubits, const cvector_t<double> &mat);
+                           const reg_t &qubits, const cvector_t<double> &mat) const override;
 };
 
 /*******************************************************************************
@@ -51,7 +51,7 @@ public:
 template <typename Container, typename data_t>
 void TransformerAVX2<Container, data_t>::apply_matrix(Container &data, size_t data_size,
                                            int threads, const reg_t &qubits,
-                                           const cvector_t<double> &mat) {
+                                           const cvector_t<double> &mat) const{
 
   if (qubits.size() == 1 &&
       ((mat[1] == 0.0 && mat[2] == 0.0) || (mat[0] == 0.0 && mat[3] == 0.0))) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Move transformer functionality to a hierarchy of classes to be able to initialize on qubitvector constructor and simplify code.

### Details and comments

Use transformer as a hierarchy of classes. In qubitvector the appropriate `transformer` class is instantiated and used along the code.

I have compared different ways of calling the `transfomer` `apply_matrix` functions:
a) As static functions, choosing with an `if` statement in qubitvector class.
b) Using virtual dispatching, through the right class instantiated in qubitvector constructor
c) Direct call to the `AVX2` static function (no selection between `AVX2` and `no-AVX2`)

It seems that performance is roughly the same:

![relative_perf](https://user-images.githubusercontent.com/59838221/94898205-73881800-0491-11eb-8105-a1ea1e442486.png)

The x axis is the number of qubits for a circuit obtained through `QuantumVolume(qubit, seed=1).decompose()` and I used the density_matrix method.
  
