### PR TITLE
Fix superoperator thrust compilation

### DIFF
--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -1941,19 +1941,20 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
   const bool can_sample = check_measure_sampling_opt(circ, method);
   
   // Cache blocking pass
+  uint_t block_bits = 0;
   if (cache_blocking) {
     auto cache_block_pass = transpile_cache_blocking(method, circ, dummy_noise, config);
     cache_block_pass.set_sample_measure(can_sample);
     cache_block_pass.optimize_circuit(circ, dummy_noise, state.opset(), result);
-    uint_t block_bits = 0;
     if (cache_block_pass.enabled()) {
       block_bits = cache_block_pass.block_bits();
     }
-    // allocate qubit register
-    state.allocate(max_qubits_, block_bits);
   }
 
-  // Check if measure sampler and optimization are valid
+  // allocate qubit register
+  state.allocate(max_qubits_, block_bits);
+
+    // Check if measure sampler and optimization are valid
   if (can_sample) {
     // Implement measure sampler
     auto& ops = circ.ops;
@@ -2005,16 +2006,18 @@ void Controller::run_circuit_with_sampled_noise(
                                   result);
     fusion_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(),
                                  result);
+    uint_t block_bits = 0;
     if (cache_blocking) {
       cache_block_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(),
                                         result);
-      uint_t block_bits = 0;
       if (cache_block_pass.enabled()) {
         block_bits = cache_block_pass.block_bits();
       }
-      // allocate qubit register
-      state.allocate(max_qubits_, block_bits);
     }
+
+    // allocate qubit register
+    state.allocate(max_qubits_, block_bits);
+
     run_single_shot(noise_circ, state, result, rng);
   }
 }

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -23,6 +23,9 @@
 #include "framework/utils.hpp"
 #include "simulators/state.hpp"
 #include "superoperator.hpp"
+#ifdef AER_THRUST_SUPPORTED
+#include "superoperator_thrust.hpp"
+#endif
 
 namespace AER {
 namespace QubitSuperoperator {
@@ -99,6 +102,8 @@ public:
   // if the controller/engine allows threads for it
   // Config: {"omp_qubit_threshold": 3}
   virtual void set_config(const json_t &config) override;
+
+  virtual void allocate(uint_t num_qubits,uint_t block_bits) override;
 
   //-----------------------------------------------------------------------
   // Additional methods
@@ -346,6 +351,11 @@ template <class data_t> void State<data_t>::initialize_omp() {
   if (BaseState::threads_ > 0)
     BaseState::qreg_.set_omp_threads(
         BaseState::threads_); // set allowed OMP threads in qubitvector
+}
+
+template <class data_t>
+void State<data_t>::allocate(uint_t num_qubits, uint_t block_bits){
+    BaseState::qreg_.chunk_setup(num_qubits * 4, num_qubits * 4, 0, 1);
 }
 
 //=========================================================================

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -355,7 +355,7 @@ template <class data_t> void State<data_t>::initialize_omp() {
 
 template <class data_t>
 void State<data_t>::allocate(uint_t num_qubits, uint_t block_bits){
-    BaseState::qreg_.chunk_setup(num_qubits * 4, num_qubits * 4, 0, 1);
+    BaseState::qreg_.chunk_setup(num_qubits * 2, num_qubits * 2, 0, 1);
 }
 
 //=========================================================================

--- a/src/simulators/superoperator/superoperator_thrust.hpp
+++ b/src/simulators/superoperator/superoperator_thrust.hpp
@@ -46,8 +46,8 @@ public:
 
   SuperoperatorThrust() : SuperoperatorThrust(0) {};
   explicit SuperoperatorThrust(size_t num_qubits);
-  SuperoperatorThrust(const Superoperator& obj) = delete;
-  Superoperator &operator=(const Superoperator& obj) = delete;
+  SuperoperatorThrust(const SuperoperatorThrust& obj) = delete;
+  SuperoperatorThrust &operator=(const SuperoperatorThrust& obj) = delete;
 
   //-----------------------------------------------------------------------
   // Utility functions
@@ -86,7 +86,7 @@ protected:
 //------------------------------------------------------------------------------
 
 template <typename data_t>
-SuperOperatorThrust<data_t>::SuperoperatorThrust(size_t num_qubits) {
+SuperoperatorThrust<data_t>::SuperoperatorThrust(size_t num_qubits) {
   set_num_qubits(num_qubits);
 }
 
@@ -95,7 +95,7 @@ SuperOperatorThrust<data_t>::SuperoperatorThrust(size_t num_qubits) {
 //------------------------------------------------------------------------------
 
 template <class data_t>
-void SuperOperatorThrust<data_t>::set_num_qubits(size_t num_qubits) {
+void SuperoperatorThrust<data_t>::set_num_qubits(size_t num_qubits) {
   num_qubits_ = num_qubits;
   // Superoperator is same size matrix as a unitary matrix
   // of twice as many qubits
@@ -104,7 +104,7 @@ void SuperOperatorThrust<data_t>::set_num_qubits(size_t num_qubits) {
 
 
 template <typename data_t>
-void SuperOperatorThrust<data_t>::initialize() {
+void SuperoperatorThrust<data_t>::initialize() {
   // Set underlying unitary matrix to identity
   BaseUnitary::initialize();
 }
@@ -112,7 +112,7 @@ void SuperOperatorThrust<data_t>::initialize() {
 
 template <class data_t>
 template <typename T>
-void SuperOperatorThrust<data_t>::initialize_from_matrix(const matrix<std::complex<T>> &mat) {
+void SuperoperatorThrust<data_t>::initialize_from_matrix(const matrix<std::complex<T>> &mat) {
   if (AER::Utils::is_square(mat)) {
     const size_t nrows = mat.GetRows();
     if (nrows == BaseUnitary::rows_) {
@@ -140,7 +140,7 @@ void SuperOperatorThrust<data_t>::initialize_from_matrix(const matrix<std::compl
 }
 
 template <class data_t>
-void SuperOperatorThrust<data_t>::initialize_from_matrix(matrix<std::complex<data_t>> &&mat) {
+void SuperoperatorThrust<data_t>::initialize_from_matrix(matrix<std::complex<data_t>> &&mat) {
   if (AER::Utils::is_square(mat)) {
     const size_t nrows = mat.GetRows();
     if (nrows == BaseUnitary::rows_) {
@@ -176,7 +176,7 @@ void SuperOperatorThrust<data_t>::initialize_from_matrix(matrix<std::complex<dat
 
 // ostream overload for templated qubitvector
 template <typename data_t>
-inline std::ostream &operator<<(std::ostream &out, const AER::QV::SuperOperatorThrust<data_t>&m) {
+inline std::ostream &operator<<(std::ostream &out, const AER::QV::SuperoperatorThrust<data_t>&m) {
   out << m.copy_to_matrix();
   return out;
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix some compilation issues. Superoperator_thrust is still not working, with some seg faults, but not sure how to go on. If superoperator_thrust is disabled everything works.

### Details and comments


